### PR TITLE
Source image name from local yaml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "structopt 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -462,7 +463,7 @@ dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -658,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -744,4 +745,4 @@ dependencies = [
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9dc3aa9dcda98b5a16150c54619c1ead22e3d3a5d458778ae914be760aa981a"
-"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"
+"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_derive = "1.0"
 serde_yaml = "0.7"
 structopt = "0.2"
 uuid = { version = "0.6", features = ["v4"] }
+yaml-rust = "0.4.3"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -47,7 +47,7 @@ image:
 image:
   yaml:
     file: .gitlab-ci.yaml
-    path: variables.RUST-IMAGE
+    key: variables.RUST-IMAGE
 ```
 
 ## Updating an image

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -16,7 +16,7 @@ The ideal workflow is
 
 # Container images
 
-`floki` offers a couple of ways t configure the container image to use.
+`floki` offers a couple of ways to configure the container image to use.
 
 ## Prebuilt images
 
@@ -38,6 +38,16 @@ image:
     name: foo                    # Will create an image called foo:floki
     dockerfile: Dockerfile.foo   # Defaults to Dockerfile
     context: .                   # Defaults to .
+```
+
+## Referencing a key in another yaml file
+`floki` can use an image referenced in another yaml file. This can help keep local development environments sync'd with a CI environment.
+
+```
+image:
+  yaml:
+    file: .gitlab-ci.yaml
+    path: variables.RUST-IMAGE
 ```
 
 ## Updating an image

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,10 @@ impl FlokiConfig {
                 yaml.file = file
                     .parent()
                     .ok_or_else(|| errors::FlokiInternalError::InternalAssertionFailed {
-                        description: format!("config_file '{:?}' does not have a parent", &file),
+                        description: format!(
+                            "could not constuct path to external yaml file '{:?}'",
+                            &yaml.file
+                        ),
                     })?
                     .join(yaml.file.clone());
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,6 +53,9 @@ pub enum FlokiError {
     #[fail(display = "Failed to check existance of image '{}': {}", image, error)]
     FailedToCheckForImage { image: String, error: io::Error },
 
+    #[fail(display = "Failed to find the specified key")]
+    FailedToFindYamlKey {},
+
     #[fail(display = "Running container failed: {}", exit_status)]
     RunContainerFailed {
         exit_status: FlokiSubprocessExitStatus,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,8 +53,8 @@ pub enum FlokiError {
     #[fail(display = "Failed to check existance of image '{}': {}", image, error)]
     FailedToCheckForImage { image: String, error: io::Error },
 
-    #[fail(display = "Failed to find the specified key")]
-    FailedToFindYamlKey {},
+    #[fail(display = "Failed to find the key '{}' in file '{}'", key, file)]
+    FailedToFindYamlKey { key: String, file: String },
 
     #[fail(display = "Running container failed: {}", exit_status)]
     RunContainerFailed {

--- a/src/image.rs
+++ b/src/image.rs
@@ -50,7 +50,6 @@ impl Image {
                 let path = yaml.key.split('.').collect::<Vec<_>>();
                 let mut val = &raw[0];
                 for key in &path {
-                    //
                     val = match key.parse::<usize>() {
                         Ok(x) => &val[x],
                         Err(_) => &val[*key],

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -15,7 +15,7 @@ pub(crate) fn run_container(
     config: &FlokiConfig,
     command: &str,
 ) -> Result<(), Error> {
-    let (mut cmd, mut dind) = build_basic_command(&floki_root, &config);
+    let (mut cmd, mut dind) = build_basic_command(&floki_root, &config)?;
 
     cmd = configure_dind(cmd, &config, &mut dind)?;
     cmd = configure_floki_user_env(cmd, &environ);
@@ -144,17 +144,17 @@ fn get_mount_specification<'a, 'b>(
 fn build_basic_command(
     floki_root: &path::Path,
     config: &FlokiConfig,
-) -> (DockerCommandBuilder, Dind) {
+) -> Result<(DockerCommandBuilder, Dind), Error> {
     let mount = get_mount_specification(&floki_root, &config);
 
     // Assign a container for docker-in-docker - we don't spawn it yet
     let dind = Dind::new(mount);
 
-    let image = &config.image.name();
+    let image = &config.image.name()?;
     let outer_shell = config.shell.outer_shell();
     let cmd = command::DockerCommandBuilder::new(image, outer_shell).add_volume(mount);
 
-    (cmd, dind)
+    Ok((cmd, dind))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,8 @@ fn run_floki_from_args(args: &Cli) -> Result<(), Error> {
         // Pull the image in the configuration file
         Some(Subcommand::Pull {}) => {
             debug!("Trying to pull image {:?}", &config.image);
-            debug!("Pulling image: {}", config.image.name());
-            image::pull_image(config.image.name())
+            debug!("Pulling image: {}", config.image.name()?);
+            image::pull_image(config.image.name()?)
         }
 
         // Run a command in the floki container


### PR DESCRIPTION
_I saw this discussed on #floki-users in the Metaswitch slack a while back. This is PR is prompted by the fact that twice in the last week I've checked in a change to a floki file or gitlab CI file, and forgot to change the other of the two..._

This adds the ability to get the image name from a local yaml file, which will make it easier to update/synchronize floki files and gitlab CI files.

I wasn't sure how to add tests for this. What would be sufficient here?

I've tested locally with the following yaml file:
```
foo:
  bar:
    - baz:
      ekidd/rust-musl-builder
  baz:
    0: ekidd/rust-musl-builder
```

Specifying the following in floki.yaml works:
```
image:
  yaml:
    file: test.yaml
    key: foo.bar.0.baz
```
as does
```
image:
  yaml:
    file: test.yaml
    key: foo.baz.0
```
There's possibly some more complex edge cases that don't work, but this should cover the vast majority of use cases. 