### PR TITLE
Deploy tagged versions to crates.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rust:
   - stable
   - nightly
   - beta
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
   fast_finish: true
@@ -25,31 +25,36 @@ before_deploy: |
   rm -rf target
   echo "Starting release build for ${LABEL}"
 
+  if [[ ${TRAVIS_OS_NAME} == "linux" ]]
+  then
+    echo "Building statically linked linux binary"
+    docker run --rm -v $(pwd):/home/rust/src -w /home/rust/src ekidd/rust-musl-builder \
+      sh -c 'sudo chown -R rust:rust . && cargo build --release && cp target/x86_64-unknown-linux-musl/release/floki .'
+    sudo chown -R travis:travis .
+    tar -cvzf floki-${LABEL}.tar.gz floki
 
-  case `uname -s` in
-      Linux)
-          echo "Building statically linked linux binary"
-          docker run --rm -v $(pwd):/home/rust/src -w /home/rust/src ekidd/rust-musl-builder \
-            sh -c 'sudo chown -R rust:rust . && cargo build --release && cp target/x86_64-unknown-linux-musl/release/floki .'
-          sudo chown -R travis:travis .
-          tar -cvzf floki-${LABEL}.tar.gz floki
-          ;;
-      *)
-          echo "Building releae binary"
-          cargo build --release
-          zip -j floki-${LABEL}.zip target/release/floki
-          ;;
-  esac
+  else
+    echo "Building release binary"
+    cargo build --release
+    zip -j floki-${LABEL}.zip target/release/floki
+
+  fi
 
   echo "Release build complete"
 
 deploy:
-  provider: releases
-  api_key:
-    secure: V9Nzptxermzw2lCgS88DLMMLnx2vMt50mHG4z1abUiP6mda+rawrL82anyoNlT+HCVwxJM7f2zR0RbyhrM6cJ/8ot4Jts7V3T5lNX6kGBw02Y5n5PfUZJmz/c6g1orjT7g96D7cnaE0wFSimLsll3aOTHb1uveS2tOSm2fcWbvYqz6hoC/nVMCU5cAXZ6+7hfGHxs1PTPRFKnmvUy2ycqx4PIdATo9NNVMxkOBh5MfLd+uAsyuRRzfZhs54FwfSNjDwtCT3Z9eDiPK8m2ncRfLQO/+KmP5mhW+5aeyaZZlgeXk8rct44Wqzu0+l91CRvBlJPN/6oOZzLMOwkyLeXDsnkuR6meONSk+TVTZUbs/3/FDm1UUFuLSX4BSY/txi+Sk2w5Ms+jmx0hAu3fCjDUMaPUHyXj2wAyOietFBUC/Ruo/88Qmcmj5XU9VYUPmZ27nsDkL6bg/sB+f97XcIXOF7etK32twBXjglq31ca3Gr4eNfIF7NJhEaIO55lZRqp6waPCslwXd8dVbtw9Tr2JmSE2FctEZk3rCLkl0FpRppoSfzBJsQB5vaJhiOzxpXCuvqMNxhvjyZlIk5per525nmCXfQs+EbkQZVfmhx9yiXHaAQ4obPSspBemsINr0c5sMNkFugOuyZ+MZjeAgG1fwE1l5mmPodB9jQbtkNtKjM=
-  file_glob: true
-  file: "floki-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.*"
-  skip_cleanup: true
-  on:
-    rust: stable
-    tags: true
+  - provider: releases
+    api_key:
+      secure: V9Nzptxermzw2lCgS88DLMMLnx2vMt50mHG4z1abUiP6mda+rawrL82anyoNlT+HCVwxJM7f2zR0RbyhrM6cJ/8ot4Jts7V3T5lNX6kGBw02Y5n5PfUZJmz/c6g1orjT7g96D7cnaE0wFSimLsll3aOTHb1uveS2tOSm2fcWbvYqz6hoC/nVMCU5cAXZ6+7hfGHxs1PTPRFKnmvUy2ycqx4PIdATo9NNVMxkOBh5MfLd+uAsyuRRzfZhs54FwfSNjDwtCT3Z9eDiPK8m2ncRfLQO/+KmP5mhW+5aeyaZZlgeXk8rct44Wqzu0+l91CRvBlJPN/6oOZzLMOwkyLeXDsnkuR6meONSk+TVTZUbs/3/FDm1UUFuLSX4BSY/txi+Sk2w5Ms+jmx0hAu3fCjDUMaPUHyXj2wAyOietFBUC/Ruo/88Qmcmj5XU9VYUPmZ27nsDkL6bg/sB+f97XcIXOF7etK32twBXjglq31ca3Gr4eNfIF7NJhEaIO55lZRqp6waPCslwXd8dVbtw9Tr2JmSE2FctEZk3rCLkl0FpRppoSfzBJsQB5vaJhiOzxpXCuvqMNxhvjyZlIk5per525nmCXfQs+EbkQZVfmhx9yiXHaAQ4obPSspBemsINr0c5sMNkFugOuyZ+MZjeAgG1fwE1l5mmPodB9jQbtkNtKjM=
+    file_glob: true
+    file: "floki-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.*"
+    skip_cleanup: true
+    on:
+      rust: stable
+      tags: true
+  - provider: cargo
+    token:
+      secure: S77Jo+z1OflPtz+j/0inlW79vVjiRy3oV4rLxwlc/e/oES5EYSqaptcHaizb+gMjhIxOkdPkwtqDe+/Kz3zKqtjtbi73OR47mS7OjUf3loYGjkMEoM3GQRbUB/Qn4y7c4AGxYLrMAK7Pl+6aktDMmKO7SGy+VmuWxNGBm5+tfQ1+dyrl6l/WajZ6fSk1SEef5T2najRu9Jn0m4zlRE2EG+iXDqiPNv7VJNDleIBWQpmnSCFWAhDn0cI+IU0qg17VzGq+nHm7sIFyM4c8TynHzOxghwnkJ+cjn7W3XCCA3vx+aWkUv5lsjqNkxmx27OBfcmAOyDIwABFSg/XdYLWiQJ+//+mmZ0y/ItNy2SxLCUA0smacZT5NOWm/hDh7mYkyGpKp/4LmhekKCRMTIDq5QPQw2zdKTomVQGxSXEHg7ilLIAfv7v/z4MV5HYtWqTN0UL768JDGJbzTjYcoaAIwgWehGWtVb+5nUAcyffVLqaulJ55DTAfzNYvk0otH6LdnEx2Bqs6btgpw2grOIhIJtHBSOJH8Xn15VGOLMw89uQlpqXXvKJ+FBvcIMjJ2KncvI9CMfC620rHga/s0752oL3YoQ/VdNwgKIlYJ575xW1najg0A7eSQ9nhAi+om3todbGuHKIcbsvPtT3CNR47/yBLC6pDuKPVeWSvyntMJZaY=
+    on:
+      rust: stable
+      tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ version number is tracked in the file `VERSION`.
 
 ## Unreleased
 ### Changed
+- Deploy tagged versions to crates.io - MINOR
+
 ### Added
 
 ## [0.3.0] - 2019-10-01

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "floki"
 version = "0.3.0"
-authors = ["Richard Lupton <richard.lupton@gmail.com>"]
+authors = ["Richard Lupton <richard.lupton@gmail.com>",
+           "Max Dymond <max.dymond@metaswitch.com>"]
 edition = '2018'
 
 [dependencies]


### PR DESCRIPTION
Use the travis cargo deployer to deploy to crates.io.

Also going to add myself to the authors list as a project maintainer.

Closes #20 