### PR TITLE
Add support for building specific dockerfile target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Status: Available for use
 ### Changed
 
 ### Added
+- Add support for specifying Dockerfile build target - MINOR
 
 ## [0.4.1] - 2019-11-12
 ### Changed

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -38,6 +38,7 @@ image:
     name: foo                    # Will create an image called foo:floki
     dockerfile: Dockerfile.foo   # Defaults to Dockerfile
     context: .                   # Defaults to .
+    target: builder              # Target to use, for multi-stage dockerfiles (optional).
 ```
 
 ## Referencing a key in another yaml file


### PR DESCRIPTION
Use case is using floki with the builder dockerfile pattern.

e.g with the following dockerfile, used to build an executable with `docker build -o . .`
```Dockerfile
# syntax=docker/dockerfile:1.1-experimental

FROM ekidd/rust-musl-builder:latest AS dev
# <install extra dev dependencies here, these will be available in floki>

FROM dev as builder
# Build our application.
RUN --mount=target=. \
    --mount=id=cargo-git,target=/home/rust/.cargo/git,type=cache,uid=1000,gid=1000 \
    --mount=id=cargo-registry,target=/home/rust/.cargo/registry,type=cache,uid=1000,gid=1000 \
    --mount=id=cargo-target,target=/home/rust/target,type=cache,uid=1000,gid=1000 \
    cargo build --release --locked --target-dir /home/rust/target && cp /home/rust/target/x86_64-unknown-linux-musl/release/using-diesel /home/rust/

FROM scratch
COPY --from=builder /home/rust/using-diesel /
```
`floki` can be configured to launch a container with the dev target in order to launch a container just before the `cargo build`.