### PR TITLE
Use sh string comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Status: Available for use
 ### Added
 - Add support for specifying Dockerfile build target - MINOR
 - Add `announce` support for notifying Slack of new changes - MINOR
+- Fix up build.sh for Linux builds - PATCH
 
 ## [0.4.1] - 2019-11-12
 ### Changed

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ LABEL=${TRAVIS_TAG}-${TRAVIS_OS_NAME}
 rm -rf target
 echo "Starting release build for ${LABEL}"
 
-if [[ ${TRAVIS_OS_NAME} == "linux" ]]
+if [ ${TRAVIS_OS_NAME} = "linux" ]
 then
   echo "Building statically linked linux binary"
   docker run --rm -v $(pwd):/home/rust/src -w /home/rust/src ekidd/rust-musl-builder \


### PR DESCRIPTION
Apparently [[ doesn't exist in the build container, so use sh string
comparison.

Fixes #49

Signed-off-by: Max Dymond <max.dymond@metaswitch.com>