### PR TITLE
Allow `dind` image to be specified in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Status: Available for use
 ### Changed
 
 ### Added
+- Allow the docker-in-docker image to be specified in configuration - MINOR
 
 ## [0.4.3] - 2019-12-02
 ### Changed

--- a/src/dind.rs
+++ b/src/dind.rs
@@ -10,9 +10,9 @@ pub struct Dind {
 }
 
 impl Dind {
-    pub fn new(mount: (&str, &str)) -> Self {
+    pub fn new(image: &str, mount: (&str, &str)) -> Self {
         Dind {
-            command: DockerCommandBuilder::new("docker:stable-dind")
+            command: DockerCommandBuilder::new(image)
                 .add_docker_switch("--privileged")
                 .add_volume(mount),
         }
@@ -36,10 +36,10 @@ impl Dind {
 }
 
 /// Check the docker dind image is available
-pub fn dind_preflight() -> Result<(), Error> {
-    if image_exists_locally("docker:stable-dind".into())? {
+pub fn dind_preflight(image: &str) -> Result<(), Error> {
+    if image_exists_locally(image)? {
         Ok(())
     } else {
-        pull_image("docker:stable-dind".into())
+        pull_image(image)
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -112,10 +112,10 @@ impl Image {
 // Now we have some functions which are useful in general
 
 /// Wrapper to pull an image by it's name
-pub fn pull_image(name: String) -> Result<(), Error> {
+pub fn pull_image(name: &str) -> Result<(), Error> {
     let exit_status = Command::new("docker")
         .arg("pull")
-        .arg(name.clone())
+        .arg(name)
         .spawn()?
         .wait()?;
 
@@ -123,7 +123,7 @@ pub fn pull_image(name: String) -> Result<(), Error> {
         Ok(())
     } else {
         Err(FlokiError::FailedToPullImage {
-            image: name.clone(),
+            image: name.into(),
             exit_status: FlokiSubprocessExitStatus {
                 process_description: "docker pull".into(),
                 exit_status: exit_status,

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -16,7 +16,7 @@ pub(crate) fn run_container(
     inner_command: &str,
 ) -> Result<(), Error> {
     let mount = get_mount_specification(&environ.floki_root, &config);
-    let dind = Dind::new(mount);
+    let dind = Dind::new(config.dind.image(), mount);
     let mut cmd = command::DockerCommandBuilder::new(&config.image.name()?).add_volume(mount);
 
     let volumes = resolve_volume_mounts(
@@ -188,7 +188,7 @@ fn launch_dind_if_needed(
     dind: Dind,
 ) -> Result<Option<command::DaemonHandle>, Error> {
     if config.dind.enabled() {
-        crate::dind::dind_preflight()?;
+        crate::dind::dind_preflight(config.dind.image())?;
         Ok(Some(dind.launch()?))
     } else {
         Ok(None)

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -52,7 +52,7 @@ fn configure_dind(
     config: &FlokiConfig,
     dind: &Dind,
 ) -> Result<DockerCommandBuilder, Error> {
-    if config.dind {
+    if config.dind.enabled() {
         Ok(command::enable_docker_in_docker(cmd, dind)?)
     } else {
         Ok(cmd)
@@ -187,7 +187,7 @@ fn launch_dind_if_needed(
     config: &FlokiConfig,
     dind: Dind,
 ) -> Result<Option<command::DaemonHandle>, Error> {
-    if config.dind {
+    if config.dind.enabled() {
         crate::dind::dind_preflight()?;
         Ok(Some(dind.launch()?))
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn run_floki_from_args(args: &Cli) -> Result<(), Error> {
         Some(Subcommand::Pull {}) => {
             debug!("Trying to pull image {:?}", &config.image);
             debug!("Pulling image: {}", config.image.name()?);
-            image::pull_image(config.image.name()?)
+            image::pull_image(&config.image.name()?)
         }
 
         // Run a command in the floki container

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -13,6 +13,7 @@ pub(crate) fn verify_command(local: bool, config: &FlokiConfig) -> Result<(), Er
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::config::DindConfig;
     use crate::config::Shell::Shell;
     use crate::image::Image::Name;
 
@@ -26,7 +27,7 @@ mod test {
             mount: "/mnt".into(),
             docker_switches,
             forward_ssh_agent: false,
-            dind: false,
+            dind: DindConfig::deactivated(),
             forward_user: false,
             volumes: BTreeMap::new(),
         }


### PR DESCRIPTION
This fixes #26, and means that a specific `dind` image can be specified in configuration.