### PR TITLE
Better path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Status: Available for use
 ### Changed
 - Change `after_deploy.sh` into a separate stage as `after_deploy:` scripts run after each `deploy:` step.
 - Resolve Dockerfile path and Docker context correctly when running `floki` from a subdirectory of the directory containing `floki.yaml` - PATCH
+- Correct and refine path handling - PATCH
 
 ### Added
 - Allow the docker-in-docker image to be specified in configuration - MINOR

--- a/src/command.rs
+++ b/src/command.rs
@@ -178,12 +178,12 @@ impl DockerCommandBuilder {
 pub fn enable_forward_ssh_agent(
     command: DockerCommandBuilder,
     agent_socket: &str,
-) -> Result<DockerCommandBuilder, Error> {
+) -> DockerCommandBuilder {
     debug!("Got SSH_AUTH_SOCK={}", agent_socket);
     let dir = path::Path::new(&agent_socket).to_path_buf();
-    Ok(command
+    command
         .add_environment("SSH_AUTH_SOCK", agent_socket)
-        .add_volume((&dir, &dir)))
+        .add_volume((&dir, &dir))
 }
 
 pub fn enable_docker_in_docker(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-use crate::errors;
 /// Configuration file format for floki
+use crate::errors;
 use crate::image;
 use failure::Error;
 use quicli::prelude::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ pub(crate) struct FlokiConfig {
     #[serde(default = "default_shell")]
     pub(crate) shell: Shell,
     #[serde(default = "default_mount")]
-    pub(crate) mount: String,
+    pub(crate) mount: path::PathBuf,
     #[serde(default = "Vec::new")]
     pub(crate) docker_switches: Vec<String>,
     #[serde(default = "default_to_false")]
@@ -140,8 +140,8 @@ fn default_shell() -> Shell {
     Shell::Shell("sh".into())
 }
 
-fn default_mount() -> String {
-    "/src".into()
+fn default_mount() -> path::PathBuf {
+    path::Path::new("/src").to_path_buf()
 }
 
 fn default_to_false() -> bool {

--- a/src/dind.rs
+++ b/src/dind.rs
@@ -1,5 +1,6 @@
 /// Docker-in-docker structures
 use failure::Error;
+use std::path;
 
 use crate::command::{DaemonHandle, DockerCommandBuilder};
 use crate::image::{image_exists_locally, pull_image};
@@ -10,7 +11,7 @@ pub struct Dind {
 }
 
 impl Dind {
-    pub fn new(image: &str, mount: (&str, &str)) -> Self {
+    pub fn new(image: &str, mount: (&path::PathBuf, &path::PathBuf)) -> Self {
         Dind {
             command: DockerCommandBuilder::new(image)
                 .add_docker_switch("--privileged")

--- a/src/image.rs
+++ b/src/image.rs
@@ -90,7 +90,10 @@ impl Image {
                     command.arg("--target").arg(target);
                 }
 
-                let exit_status = command.arg(&floki_root.join(&build.context)).spawn()?.wait()?;
+                let exit_status = command
+                    .arg(&floki_root.join(&build.context))
+                    .spawn()?
+                    .wait()?;
                 if exit_status.success() {
                     Ok(self.name()?)
                 } else {

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -141,7 +141,7 @@ fn configure_volumes(
 ) -> DockerCommandBuilder {
     let mut cmd = cmd; // Shadow as mutable
     for (src, dst) in volumes.iter() {
-        cmd = cmd.add_volume((src.to_str().unwrap(), dst.to_str().unwrap()));
+        cmd = cmd.add_volume((src, dst));
     }
     cmd
 }
@@ -168,10 +168,10 @@ fn get_working_directory(
 
 /// Specify the primary mount for the floki container
 fn get_mount_specification<'a, 'b>(
-    floki_root: &'a path::Path,
+    floki_root: &'a path::PathBuf,
     config: &'b FlokiConfig,
-) -> (&'a str, &'b str) {
-    (&floki_root.to_str().unwrap(), &config.mount)
+) -> (&'a path::PathBuf, &'b path::PathBuf) {
+    (floki_root, &config.mount)
 }
 
 /// Turn the init section of a floki.yaml file into a command

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -97,7 +97,7 @@ fn configure_forward_ssh_agent(
 ) -> Result<DockerCommandBuilder, Error> {
     if config.forward_ssh_agent {
         if let Some(ref path) = env.ssh_agent_socket {
-            Ok(command::enable_forward_ssh_agent(cmd, path)?)
+            Ok(command::enable_forward_ssh_agent(cmd, path))
         } else {
             Err(errors::FlokiError::NoSshAuthSock {})?
         }

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -137,7 +137,7 @@ fn configure_working_directory(
 /// Add mounts for each of the passed in volumes
 fn configure_volumes(
     cmd: DockerCommandBuilder,
-    volumes: &Vec<(path::PathBuf, path::PathBuf)>,
+    volumes: &Vec<(path::PathBuf, &path::PathBuf)>,
 ) -> DockerCommandBuilder {
     let mut cmd = cmd; // Shadow as mutable
     for (src, dst) in volumes.iter() {
@@ -147,7 +147,7 @@ fn configure_volumes(
 }
 
 /// Create the backing directories for floki volumes if needed
-fn instantiate_volumes(volumes: &Vec<(path::PathBuf, path::PathBuf)>) -> Result<(), Error> {
+fn instantiate_volumes(volumes: &Vec<(path::PathBuf, &path::PathBuf)>) -> Result<(), Error> {
     for (src, _) in volumes.iter() {
         std::fs::create_dir_all(src)?;
     }

--- a/src/volumes.rs
+++ b/src/volumes.rs
@@ -8,17 +8,17 @@ use crate::config::Volume;
 
 static VOLUME_DIRECTORY: &str = "volumes/";
 
-pub(crate) fn resolve_volume_mounts(
+pub(crate) fn resolve_volume_mounts<'a>(
     config_filepath: &path::PathBuf,
     work_path: &path::PathBuf,
-    volumes: &BTreeMap<String, Volume>,
-) -> Vec<(path::PathBuf, path::PathBuf)> {
+    volumes: &'a BTreeMap<String, Volume>,
+) -> Vec<(path::PathBuf, &'a path::PathBuf)> {
     volumes
         .iter()
         .map(|(name, volume)| {
             (
                 cache_path(work_path, config_filepath, name, volume),
-                volume.mount.clone(),
+                &volume.mount,
             )
         })
         .collect()


### PR DESCRIPTION
There are places (#60) in `floki` where paths aren't dealt with correctly - there is no guarantee that a path can be utf-8 decoded, but we assume it always can.

This MR uses the correct types with paths, and tidies up some of the code surrounding them. Even if in practice most paths are valid utf-8, this change makes the code more correct, and clearer, as well as avoiding a few unneeded allocations. Correcter, cleaner, faster!