### PR TITLE
Remove logging verbosity option from CLI to restore working build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Status: Available for use
 - Bump serde_yaml from 0.7.5 to 0.8.4 - PATCH
 - Bump structopt from 0.2.18 to 0.3.13 - PATCH
 - Bump uuid from 0.6.5 to 0.8.1 - PATCH
+- *TEMPORARY* Remove logging verbosity switch to restore working build
 
 ### Added
 - Allow the docker-in-docker image to be specified in configuration - MINOR

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-use quicli::prelude::*;
 /// Description of the CLI interface to floki
 use std::path;
 use structopt::StructOpt;
@@ -27,9 +26,6 @@ pub(crate) struct Cli {
     /// Run floki regardless of reproducibility
     #[structopt(long = "local", short = "l")]
     pub(crate) local: bool,
-
-    #[structopt(flatten)]
-    pub(crate) verbosity: Verbosity,
 
     #[structopt(subcommand)]
     pub(crate) subcommand: Option<Subcommand>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ use structopt::StructOpt;
 
 fn main() -> CliResult {
     let args = Cli::from_args();
-    args.verbosity.setup_env_logger("floki")?;
 
     match run_floki_from_args(&args) {
         Ok(()) => (),


### PR DESCRIPTION
Signed-off-by: Richard Lupton <richard.lupton@gmail.com>