### PR TITLE
Use proper path types for working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Status: Available for use
 
 ## [Unreleased]
 ### Changed
+- Cleanup of resolution of working directory to use proper path types - PATCH
 
 ### Added
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -132,14 +132,12 @@ impl DockerCommandBuilder {
         self
     }
 
-    pub fn add_docker_switch(mut self, switch: &str) -> Self {
-        for s in switch.split_whitespace() {
-            self.switches.push(s.into());
-        }
+    pub fn add_docker_switch<S: AsRef<OsStr>>(mut self, switch: S) -> Self {
+        self.switches.push(switch.as_ref().into());
         self
     }
 
-    pub fn set_working_directory(self, directory: &str) -> Self {
+    pub fn set_working_directory<S: AsRef<OsStr>>(self, directory: S) -> Self {
         let mut cmd = self;
         cmd = cmd.add_docker_switch("-w");
         cmd = cmd.add_docker_switch(directory);

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -79,7 +79,8 @@ fn configure_forward_user(
 ) -> DockerCommandBuilder {
     if config.forward_user {
         let (ref user, ref group) = env.user_details;
-        cmd.add_docker_switch(&format!("--user {}:{}", user, group))
+        cmd.add_docker_switch("--user")
+            .add_docker_switch(&format!("{}:{}", user, group))
     } else {
         cmd
     }
@@ -107,7 +108,9 @@ fn configure_docker_switches(
 ) -> DockerCommandBuilder {
     let mut cmd = cmd;
     for switch in &config.docker_switches {
-        cmd = cmd.add_docker_switch(&switch);
+        for s in switch.split_whitespace() {
+            cmd = cmd.add_docker_switch(s);
+        }
     }
 
     cmd
@@ -118,15 +121,11 @@ fn configure_working_directory(
     env: &Environment,
     config: &FlokiConfig,
 ) -> DockerCommandBuilder {
-    cmd.set_working_directory(
-        get_working_directory(
-            &env.current_directory,
-            &env.floki_root,
-            &path::PathBuf::from(&config.mount),
-        )
-        .to_str()
-        .unwrap(),
-    )
+    cmd.set_working_directory(get_working_directory(
+        &env.current_directory,
+        &env.floki_root,
+        &path::PathBuf::from(&config.mount),
+    ))
 }
 
 /// Add mounts for each of the passed in volumes


### PR DESCRIPTION
This removes the unsafe conversion to `str` of the working directory,
and also changes the `add_docker_switch` function to uniformly take a
single switch (rather than possibly many, separated by whitespace),
and also to take input which is reference generic over `OsStr`.

Signed-off-by: Richard Lupton <richard.lupton@gmail.com>