### PR TITLE
Improve uid/gid queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Status: Available for use
 ## [Unreleased]
 ### Changed
 - Cleanup of resolution of working directory to use proper path types - PATCH
+- Cleanup and improve handling of user uid and gid - PATCH
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ version = "0.5.0"
 dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,8 +215,8 @@ version = "0.5.0"
 dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -363,6 +368,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -845,6 +862,11 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +926,7 @@ dependencies = [
 "checksum backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+"checksum cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
@@ -937,6 +960,7 @@ dependencies = [
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memoffset 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 "checksum miniz_oxide 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
@@ -994,6 +1018,7 @@ dependencies = [
 "checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "0.8", features = ["v4"] }
 yaml-rust = "0.4.4"
 rust-crypto = "^0.2"
 simplelog = "0.8"
-libc = "0.2"
+nix = "0.17"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ uuid = { version = "0.8", features = ["v4"] }
 yaml-rust = "0.4.4"
 rust-crypto = "^0.2"
 simplelog = "0.8"
+libc = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -8,9 +8,9 @@ use std::path;
 #[derive(Debug, Clone, Copy)]
 pub struct User {
     /// The users uid
-    pub uid: libc::uid_t,
+    pub uid: nix::unistd::Uid,
     /// The users gid
-    pub gid: libc::gid_t,
+    pub gid: nix::unistd::Gid,
 }
 
 #[derive(Debug)]
@@ -49,10 +49,9 @@ impl Environment {
 
 /// Get the user and group ids of the current user
 fn get_user_details() -> User {
-    let uid = getuid();
-    debug!("User's current id: {}", uid);
-    let gid = getgid();
-    debug!("User's current group: {}", gid);
+    let uid = nix::unistd::getuid();
+    let gid = nix::unistd::getgid();
+    debug!("Current user has uid {} and group {}", uid, gid);
     User { uid, gid }
 }
 
@@ -102,7 +101,7 @@ fn resolve_floki_root_and_config(
 }
 
 /// Resolve a directory for floki to use for user-global file (caches etc)
-fn get_floki_work_path(uid: libc::uid_t) -> path::PathBuf {
+fn get_floki_work_path(uid: nix::unistd::Uid) -> path::PathBuf {
     let root: path::PathBuf = env::var("HOME").unwrap_or(format!("/tmp/{}/", uid)).into();
     root.join(".floki")
 }
@@ -118,16 +117,6 @@ fn normalize_path(path: path::PathBuf) -> Result<path::PathBuf, Error> {
     })?;
 
     Ok(res)
-}
-
-/// Safe wrapper for the getuid function
-fn getuid() -> libc::uid_t {
-    unsafe { libc::getuid() }
-}
-
-/// Safe wrapper for the getgid function
-fn getgid() -> libc::gid_t {
-    unsafe { libc::getgid() }
 }
 
 #[cfg(test)]

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -60,9 +60,9 @@ fn configure_dind(
 }
 
 fn configure_floki_user_env(cmd: DockerCommandBuilder, env: &Environment) -> DockerCommandBuilder {
-    let (ref user, ref group) = env.user_details;
-    let new_cmd = cmd.add_environment("FLOKI_HOST_UID", &user);
-    new_cmd.add_environment("FLOKI_HOST_GID", &group)
+    let (user, group) = env.user_details;
+    let new_cmd = cmd.add_environment("FLOKI_HOST_UID", user.to_string());
+    new_cmd.add_environment("FLOKI_HOST_GID", group.to_string())
 }
 
 fn configure_floki_host_mountdir_env(

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -60,9 +60,9 @@ fn configure_dind(
 }
 
 fn configure_floki_user_env(cmd: DockerCommandBuilder, env: &Environment) -> DockerCommandBuilder {
-    let (user, group) = env.user_details;
-    let new_cmd = cmd.add_environment("FLOKI_HOST_UID", user.to_string());
-    new_cmd.add_environment("FLOKI_HOST_GID", group.to_string())
+    let user = env.user_details;
+    let new_cmd = cmd.add_environment("FLOKI_HOST_UID", user.uid.to_string());
+    new_cmd.add_environment("FLOKI_HOST_GID", user.gid.to_string())
 }
 
 fn configure_floki_host_mountdir_env(
@@ -78,9 +78,9 @@ fn configure_forward_user(
     env: &Environment,
 ) -> DockerCommandBuilder {
     if config.forward_user {
-        let (ref user, ref group) = env.user_details;
+        let user = env.user_details;
         cmd.add_docker_switch("--user")
-            .add_docker_switch(&format!("{}:{}", user, group))
+            .add_docker_switch(&format!("{}:{}", user.uid, user.gid))
     } else {
         cmd
     }


### PR DESCRIPTION
The querying of uid and gid always used weird string junk code and a subprocess (lord knows why I did that). This replaces it with the obvious and much more sensible system calls.

In the process I cleaned up some other cruft and put a little structure around the uid/gid pair, just to remove tuple ordering mistakes etc.