### PR TITLE
Add a basic pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Why this change?
+
+Describe this change, including why it's needed.
+
+## Relevant testing
+
+What testing has been done?
+
+## Contributor notes
+
+Anything you think will be useful for reviewers.
+
+## Checks
+
+These aren't hard requirements, just guidelines
+
+- [ ] New/modified Rust code formatted with `cargo fmt`
+


### PR DESCRIPTION
Nothing too fancy, I thought it would be worth making a start on some of these basic healthy repository things. I've found these little templates quite nice for lightweight joggers for things that you ought to do on a PR (e.g. run `cargo fmt` - we could do this in CI, but I find this more annoying than anything, especially when more pressing work needs merging).

Signed-off-by: Richard Lupton <richard.lupton@gmail.com>