### PR TITLE
Fix parsing of docker_switches to adhere to shell quoting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Status: Available for use
 
 ### Fixed
 - Don't require a floki config file to be present to run `floki completion`
+- Properly parse `docker_switches` in accordance with shell quoting rules
 
 ## [0.6.1] - 2020-07-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
+ "shlex",
  "simplelog",
  "structopt 0.3.21",
  "tempdir",
@@ -766,6 +767,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simplelog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ yaml-rust = "0.4.4"
 rust-crypto = "^0.2"
 simplelog = "0.9"
 nix = "0.19"
+shlex = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,6 +65,9 @@ pub enum FlokiError {
 
     #[fail(display = "Unable to forward ssh socket - cannot find SSH_AUTH_SOCK in environment")]
     NoSshAuthSock {},
+
+    #[fail(display = "Malformed item in docker_switches: {}", item)]
+    MalformedDockerSwitch { item: String },
 }
 
 /// Generate a summary string for a process exiting


### PR DESCRIPTION
## Why this change?

At present `floki` doesn't handle quoted arguments properly in the `docker_switches` escape hatch. This adds proper shell compliant parsing of these switches.

## Relevant testing

Tested by hand

```
docker_switches:
        - -e FOO="bar this that other"
```

```
$ ./target/x86_64-unknown-linux-musl/debug/floki run -- echo '$FOO'
bar this that other
```

Error case (missing closing quote):

```
docker_switches:
        - -e FOO="bar this that other
```

```
$ ./target/x86_64-unknown-linux-musl/debug/floki run -- echo '$FOO'
23:54:45 [ERROR] A problem occurred: Malformed item in docker_switches: -e FOO="bar this that other
```

## Contributor notes

I don't think this should break anything that wasn't already broken. It would be nice if this were a little more testable, and more generally I'd like to push the validation (and flattening) of this kind of thing further toward the start of the program, so the rest can just be dumb and simple. Not for now, and perhaps only for when a need to simplify this occurs, or someone fancies the cleanup. It's hard to imagine this program getting wildly more complicated!

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`

