### PR TITLE
Suppress entrypoints by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ Status: Available for use
 
 ### Changed
 
+- Automatically suppress the container entrypoint - MAJOR
+
 ### Added
+
+- Allow entrypoint suppression to be set in the configuration file - MINOR
 
 ### Fixed
 

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -98,6 +98,15 @@ init:
 
 The commands to make the above work depend on the container you are running. `floki` just provides the tools to allow you to make it happen.
 
+# Entrypoints
+
+By default `floki` will suppress the container entrypoint. This can be overridden in the configuration file with:
+
+```yaml
+entrypoint:
+  suppress: false
+```
+
 # Docker-in-docker
 
 Docker-in-docker (`dind`) can be enabled by setting the top-level `dind` key to `true`.


### PR DESCRIPTION
## Why this change?

This was motivated by #163.

## Relevant testing

Unit testing of configuration parsing, live tests of docker container configuration.

## Contributor notes

I originally added an explicit entrypoint setting key:

```
entrypoint: thing
```

but figured this would probably never be used. If that turns out to be wrong, we should add it back in. `docker_switches` can be used in the meantime.

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

