### PR TITLE
Update simplelog to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Status: Available for use
 ### Changed
 
 - Automatically suppress the container entrypoint - MAJOR
+- Update simplelog from 0.9 to 0.10 - MINOR
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,9 +723,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "simplelog"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc0ffd69814a9b251d43afcabf96dad1b29f5028378056257be9e3fecc9f720"
+checksum = "59d0fe306a0ced1c88a58042dc22fc2ddd000982c26d75f6aa09a394547c41e0"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ structopt = "0.3"
 uuid = { version = "0.8", features = ["v4"] }
 yaml-rust = "0.4.4"
 rust-crypto = "^0.2"
-simplelog = "0.9"
+simplelog = "0.10"
 nix = "0.20"
 shlex = "1.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn configure_logging(verbosity: u8) -> Result<(), Error> {
         level,
         simplelog::Config::default(),
         simplelog::TerminalMode::Stderr,
+        simplelog::ColorChoice::Auto,
     )?;
     Ok(())
 }


### PR DESCRIPTION
Needed manual intervention to update to a newer API.

Signed-off-by: Richard Lupton <richard.lupton@gmail.com>

## Why this change?

Routine dependency update with manual intervention required for an API update.

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

