### PR TITLE
Simplify core processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Status: Available for use
 
 - Automatically suppress the container entrypoint - MAJOR
 - Update simplelog from 0.9 to 0.10 - MINOR
+- Rework internals to have clear data structure for the runtime configuration - MINOR
 
 ### Added
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,20 +42,6 @@ impl DindConfig {
     pub fn deactivated() -> Self {
         DindConfig::Toggle(false)
     }
-
-    pub fn enabled(&self) -> bool {
-        match self {
-            DindConfig::Toggle(v) => *v,
-            _ => true,
-        }
-    }
-
-    pub fn image(&self) -> &str {
-        match self {
-            DindConfig::Image { image } => image,
-            _ => "docker:stable-dind",
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -218,8 +204,6 @@ mod test {
         };
         let actual: TestDindConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(actual, expected);
-        assert_eq!(actual.dind.enabled(), true);
-        assert_eq!(actual.dind.image(), "docker:stable-dind");
     }
 
     #[test]
@@ -232,8 +216,6 @@ mod test {
         };
         let actual: TestDindConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(actual, expected);
-        assert_eq!(actual.dind.enabled(), true);
-        assert_eq!(actual.dind.image(), "dind:custom");
     }
 
     #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,7 @@ fn run_floki_from_args(args: &Cli) -> Result<(), Error> {
             let env = Environment::gather(&args.config_file)?;
             let config = FlokiConfig::from_file(&env.config_file)?;
             let inner_command = interpret::command_in_shell(config.shell.inner_shell(), &command);
-            interpret::run_floki_container(
-                &spec::FlokiEnvironment::from(config, env)?,
-                &inner_command,
-            )
+            interpret::run_floki_container(&spec::FlokiSpec::from(config, env)?, &inner_command)
         }
 
         Some(Subcommand::Completion { shell }) => {
@@ -75,10 +72,7 @@ fn run_floki_from_args(args: &Cli) -> Result<(), Error> {
             let env = Environment::gather(&args.config_file)?;
             let config = FlokiConfig::from_file(&env.config_file)?;
             let inner_command = config.shell.inner_shell().to_string();
-            interpret::run_floki_container(
-                &spec::FlokiEnvironment::from(config, env)?,
-                &inner_command,
-            )
+            interpret::run_floki_container(&spec::FlokiSpec::from(config, env)?, &inner_command)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod errors;
 mod image;
 mod interpret;
 mod volumes;
+mod spec;
 
 use cli::{Cli, Subcommand};
 use config::FlokiConfig;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,0 +1,110 @@
+use crate::config::{DindConfig, FlokiConfig};
+use crate::errors;
+use crate::environment::Environment;
+
+use failure::Error;
+
+use std::collections::BTreeMap;
+use std::path;
+use std::ffi::OsString;
+
+pub(crate) struct Docker {
+    pub(crate) image: String,
+}
+
+pub(crate) struct User {
+    pub(crate) forward: bool,
+    pub(crate) uid: nix::unistd::Uid,
+    pub(crate) gid: nix::unistd::Gid,
+}
+
+pub(crate) struct SshAgent {
+    pub(crate) path: OsString,
+}
+
+pub(crate) struct Paths {
+    pub(crate) current_directory: path::PathBuf,
+    pub(crate) root: path::PathBuf,
+    pub(crate) config: path::PathBuf,
+    pub(crate) workspace: path::PathBuf,
+}
+
+/// A fully resolved specification of a container to run
+pub(crate) struct FlokiEnvironment {
+    /// Details of the image to use
+    pub(crate) image: crate::image::Image,
+    /// Commands to run on initialization
+    pub(crate) init: Vec<String>,
+    /// Shell to use in the environment
+    pub(crate) shell: crate::config::Shell,
+    /// Where to mount the working directory
+    pub(crate) mount: path::PathBuf,
+    /// Entrypoint
+    pub(crate) entrypoint: Option<String>,
+    /// Volumes to mount into the container
+    pub(crate) volumes: BTreeMap<String, crate::config::Volume>,
+    /// User details and forwarding
+    pub(crate) user: User,
+    /// SSH agent forwarding
+    pub(crate) ssh: Option<SshAgent>,
+    /// Explicit docker switches to use
+    pub(crate) docker_switches: Vec<String>,
+    /// Linked docker environments
+    pub(crate) docker: Option<Docker>,
+    /// Paths on the host which are relevant to running
+    pub(crate) paths: Paths,
+}
+
+impl FlokiEnvironment {
+    pub(crate) fn from(
+        config: FlokiConfig,
+        environ: Environment,
+    ) -> Result<FlokiEnvironment, Error> {
+        let docker = match config.dind {
+            DindConfig::Toggle(true) => Some(Docker {
+                image: "docker:stable-dind".to_string(),
+            }),
+            DindConfig::Toggle(false) => None,
+            DindConfig::Image { image } => Some(Docker { image }),
+        };
+
+        let user = User {
+            forward: config.forward_user,
+            uid: environ.user_details.uid,
+            gid: environ.user_details.gid,
+        };
+
+        let entrypoint = config.entrypoint.value().map(|v| v.to_string());
+
+        let ssh = if config.forward_ssh_agent {
+            if let Some(path) = environ.ssh_agent_socket {
+                Ok(Some(SshAgent { path }))
+            } else {
+                Err(errors::FlokiError::NoSshAuthSock {})
+            }?
+        } else {
+            None
+        };
+
+        let paths = Paths {
+	    current_directory: environ.current_directory,
+            root: environ.floki_root,
+            config: environ.config_file,
+            workspace: environ.floki_workspace,
+        };
+
+        Ok(FlokiEnvironment {
+            image: config.image,
+            init: config.init,
+            mount: config.mount,
+            shell: config.shell,
+            entrypoint,
+            volumes: config.volumes,
+            user,
+            ssh,
+            docker_switches: config.docker_switches,
+            docker,
+            paths,
+        })
+    }
+}

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,12 +1,12 @@
 use crate::config::{DindConfig, FlokiConfig};
-use crate::errors;
 use crate::environment::Environment;
+use crate::errors;
 
 use failure::Error;
 
 use std::collections::BTreeMap;
-use std::path;
 use std::ffi::OsString;
+use std::path;
 
 pub(crate) struct Docker {
     pub(crate) image: String,
@@ -87,7 +87,7 @@ impl FlokiEnvironment {
         };
 
         let paths = Paths {
-	    current_directory: environ.current_directory,
+            current_directory: environ.current_directory,
             root: environ.floki_root,
             config: environ.config_file,
             workspace: environ.floki_workspace,


### PR DESCRIPTION
## Why this change?

This change breaks apart the two levels of processing that were taking place in the interpret module. This adds a new structure (`FlokiSpec`) which is a fully resolved and checked piece of configuration, which makes building the docker command much more straightforward. Many small procedures can then be inlined or deleted, which generally helps clarity.

## Relevant testing

Manual runs with various bits of configuration.

## Contributor notes

None.

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [N/A] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

