### PR TITLE
Add exec mode for generating images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Status: Available for use
 ### Added
 
 - Allow entrypoint suppression to be set in the configuration file - MINOR
+- Add exec mode for generating images - MINOR
 
 ### Fixed
 

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -53,6 +53,22 @@ image:
     key: variables.RUST-IMAGE
 ```
 
+## Build an image using any tool
+
+`floki` can use an image built using any arbitrary tool.
+
+```yaml
+image:
+  exec:
+    command: docker              # Will execute the program "docker"
+    args:                        # A set of arguments to be passed to the command
+      - build
+      - -t
+      - devimage
+      - .
+    image: devimage              # The name and tag of the image that is created by the command
+```
+
 ## Updating an image
 
 `floki pull` forces a pull of the container specified in `image`. While it is better to version images properly, this can be used when tracking a `latest` tag, or similar.

--- a/src/image.rs
+++ b/src/image.rs
@@ -27,7 +27,7 @@ pub struct YamlSpec {
 pub struct ExecSpec {
     command: String,
     args: Vec<String>,
-    tag: String,
+    image: String,
 }
 
 fn default_dockerfile() -> PathBuf {
@@ -77,7 +77,7 @@ impl Image {
                         .into()
                     })
             }
-            Image::Exec { ref exec } => Ok(exec.tag.clone()),
+            Image::Exec { ref exec } => Ok(exec.image.clone()),
         }
     }
 
@@ -227,14 +227,14 @@ image:
         command: foo
         args:
             - build
-        tag: "foobuild:1.0.0"
+        image: "foobuild:1.0.0"
 "#;
         let expected = TestImage {
             image: Image::Exec {
                 exec: ExecSpec {
                     command: "foo".into(),
                     args: vec!["build".into()],
-                    tag: "foobuild:1.0.0".into(),
+                    image: "foobuild:1.0.0".into(),
                 },
             },
         };


### PR DESCRIPTION
Signed-off-by: Max Dymond <max.dymond@microsoft.com>

## Why this change?

It'd be nice to support third party tools that generate docker images (and aren't docker)

## Relevant testing

Unit testing. I've tested locally as well.

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [ ] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

