### PR TITLE
Adjust error for failing to find ssh-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Status: Available for use
 
 ### Changed
 
+- Adjust SSH agent forwarding error message - MINOR
+
 ### Added
 
 ### Fixed

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,7 +57,7 @@ pub enum FlokiError {
         exit_status: FlokiSubprocessExitStatus,
     },
 
-    #[error("Unable to forward ssh socket - cannot find SSH_AUTH_SOCK in environment")]
+    #[error("Unable to forward ssh socket - cannot find SSH_AUTH_SOCK in environment - do you have an ssh agent running?")]
     NoSshAuthSock {},
 
     #[error("Malformed item in docker_switches: {item}")]


### PR DESCRIPTION
## Why this change?

This improves the error message around failing to find the ssh-agent socket path - people don't seem to know `SSH_AUTH_SOCK` pertains to having a running ssh-agent configured in the environment (which is fair enough).

## Relevant testing

What testing has been done?

```
$ unset SSH_AUTH_SOCK
$ ./target/x86_64-unknown-linux-musl/debug/floki
21:02:12 [ERROR] A problem occurred: Unable to forward ssh socket - cannot find SSH_AUTH_SOCK in environment - do you have an ssh agent running?
```

## Contributor notes

N/A

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [N/A] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

