### PR TITLE
Change stable-dind to dind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ Status: Available for use
 ### Breaking Changes
 
 ### Added
+- Change docker in docker image tag from `stable-dind` to `dind`
 
 ### Fixed
 
 - Fix up clippy warnings and enforce clippy going forward
-- Change docker in docker image tag from `stable-dind` to `dind`
+- `image_exists_locally` now checks that the specified image exists
 ## [0.7.1] - 2021-12-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Status: Available for use
 ### Fixed
 
 - Fix up clippy warnings and enforce clippy going forward
-
+- Change docker in docker image tag from `stable-dind` to `dind`
 ## [0.7.1] - 2021-12-08
 
 ### Fixed

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -138,7 +138,7 @@ The precise `dind` image can also be set
 
 ```yaml
 dind:
-  image: docker:stable-dind
+  image: docker:dind
 ```
 
 This helps properly pin and version the docker-in-docker container.

--- a/src/dind.rs
+++ b/src/dind.rs
@@ -5,6 +5,8 @@ use std::path;
 use crate::command::{DaemonHandle, DockerCommandBuilder};
 use crate::image::{image_exists_locally, pull_image};
 
+pub const DEFAULT_DIND_IMAGE: &str = "docker:dind";
+
 #[derive(Debug)]
 pub struct Dind {
     command: DockerCommandBuilder,

--- a/src/image.rs
+++ b/src/image.rs
@@ -168,8 +168,9 @@ pub fn pull_image(name: &str) -> Result<(), Error> {
 
 /// Determine whether an image exists locally
 pub fn image_exists_locally(name: &str) -> Result<bool, Error> {
+    debug!("Checking for image: {}", name);
     let ret = Command::new("docker")
-        .args(&["history", "docker:dind"])
+        .args(&["history", name])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -178,7 +179,6 @@ pub fn image_exists_locally(name: &str) -> Result<bool, Error> {
             image: name.to_string(),
             error: e,
         })?;
-
     Ok(ret.code() == Some(0))
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -169,7 +169,7 @@ pub fn pull_image(name: &str) -> Result<(), Error> {
 /// Determine whether an image exists locally
 pub fn image_exists_locally(name: &str) -> Result<bool, Error> {
     let ret = Command::new("docker")
-        .args(&["history", "docker:stable-dind"])
+        .args(&["history", "docker:dind"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,4 +1,5 @@
 use crate::config::{DindConfig, FlokiConfig};
+use crate::dind::DEFAULT_DIND_IMAGE;
 use crate::environment::Environment;
 use crate::errors;
 
@@ -79,7 +80,7 @@ impl FlokiSpec {
     pub(crate) fn from(config: FlokiConfig, environ: Environment) -> Result<Self, Error> {
         let dind = match config.dind {
             DindConfig::Toggle(true) => Some(Dind {
-                image: "docker:dind".to_string(),
+                image: DEFAULT_DIND_IMAGE.to_string(),
             }),
             DindConfig::Toggle(false) => None,
             DindConfig::Image { image } => Some(Dind { image }),

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -79,7 +79,7 @@ impl FlokiSpec {
     pub(crate) fn from(config: FlokiConfig, environ: Environment) -> Result<Self, Error> {
         let dind = match config.dind {
             DindConfig::Toggle(true) => Some(Dind {
-                image: "docker:stable-dind".to_string(),
+                image: "docker:dind".to_string(),
             }),
             DindConfig::Toggle(false) => None,
             DindConfig::Image { image } => Some(Dind { image }),


### PR DESCRIPTION
## Why this change?

The `stable-dind` tag doesn't appear to be maintained. Change the default docker image tag to `dind` which appears to be maintained.

## Relevant testing

Spun up a container with the `dind:true` field in `floki.yaml`. Tested that the docker container used had the tag `dind`. 

## Checks

These aren't hard requirements, just guidelines

- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

