### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,15 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "nix"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,7 +233,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ structopt = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 yaml-rust = "0.4.4"
 simplelog = "0.12"
-nix = "0.24"
+nix = { version = "0.24", default-features = false, features = ["user"] }
 shlex = "1.1"
 sha2 = "0.10.2"
 anyhow = "1.0.57"


### PR DESCRIPTION
## Why this change?

This makes compiling `floki` slightly faster.

## Relevant testing

Built and ran tests on Fedora 36.

## Contributor notes

`cargo build --timings` is a nice way to inspect the build times.

## Checks

I don't believe any of these apply.

- [ ] New/modified Rust code formatted with `cargo fmt`
- [ ] Documentation and `README.md` updated for this change, if necessary
- [ ] `CHANGELOG.md` updated for this change

