### PR TITLE
Don't add -i to docker command when stdin is not a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Status: Available for use
 ### Added
 
 ### Fixed
+- Don't add "-i" to docker commands when stdin is not a tty. This allows commands `floki run -- <command>` to be run from inside other scripts even if stdout looks like a tty.
 
 ## [1.0.0] - 2022-09-12
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -178,7 +178,7 @@ impl DockerCommandBuilder {
 
     fn base_args(&self) -> Vec<&OsStr> {
         let mut base_args: Vec<&OsStr> = vec!["run".as_ref(), "--rm".as_ref(), "-t".as_ref()];
-        if atty::is(atty::Stream::Stdout) {
+        if atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stdin) {
             base_args.push("-i".as_ref());
         }
         base_args


### PR DESCRIPTION
## Why this change?

Hi! 

This fixes uses of floki in script environments where stdout appears to be a TTY, but stdin is not.

## Relevant testing

The most basic repro scenario of the problem is:

```
$ echo "" | floki
the input device is not a TTY
10:21:41 [ERROR] A problem occurred: Running container failed: docker run exited with return code 1
```

(I'm not actually trying to pipe anything into floki - the tool I'm using which wants to run floki just doesn't have stdin as a TTY).

Running this with the fix means the above command (and my specific scripted scenario) works correctly.

Didn't see a way to add any regression test to cover this case.

Should be perfectly safe - in any case where stdin was not a TTY, which is the only case this impacts, then floki would have failed.

## Contributor notes

If you accept, **could you please release a new version with this fix included**, so that I can get this working for my use case?

Thanks!

## Checks

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

