### PR TITLE
Update to ubuntu-20.04 and add a dependabot update rule for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: serde
-    versions:
-    - 1.0.123
-    - 1.0.124
-  - dependency-name: log
-    versions:
-    - 0.4.14
-  - dependency-name: serde_yaml
-    versions:
-    - 0.8.16
-  - dependency-name: serde_derive
-    versions:
-    - 1.0.123
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: serde
+        versions:
+          - 1.0.123
+          - 1.0.124
+      - dependency-name: log
+        versions:
+          - 0.4.14
+      - dependency-name: serde_yaml
+        versions:
+          - 0.8.16
+      - dependency-name: serde_derive
+        versions:
+          - 1.0.123
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-latest
         rust:
           - stable
           - beta
         experimental: [false]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             rust: nightly
             experimental: true
     steps:
@@ -57,7 +57,7 @@ jobs:
             floki*.tar.gz
 
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - build
     steps:

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-if [ $OS_NAME = "ubuntu-18.04" ]
+if [ $OS_NAME = "ubuntu-20.04" ]
 then
   OS_ID="linux"
 elif [ $OS_NAME = "macos-latest" ]


### PR DESCRIPTION
Seems like github actions have an issue with Ubuntu 18.04. Let's update to 20.04, and also run dependabot for github actions at the same time.