### PR TITLE
Add support for floki to interpret host environmental variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Status: Available for use
 ## [Unreleased]
 
 ### Breaking Changes
+- Allow templating using environmental variables in `floki.yaml`, with `${user_env:VAR}` replaced with value of the user's environmental variable `VAR` before deserialization.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ shlex = "1.1"
 sha2 = "0.10.7"
 anyhow = "1.0.71"
 thiserror = "1.0.40"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3.6.0"

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -222,3 +222,18 @@ Note that use of `docker_switches` may reduce the reproducibility and shareabili
 
 Nonetheless, it is useful to be able to add arbitrary switches in a pinch, just to be able to get something working.
 If there are things you can add with `docker_switches` which are reproducible and shareable, please raise a feature request, or go ahead and implement it yourself!
+
+# Using environmental variables in yaml
+
+Sometimes it is helpful for the `floki` config to include environment-specific values.  For example, mounting a subdirectory of the user's home directory.  `floki` supports this via templating.  Specify environmental variables in `floki.yaml` as `${user_env:<ENV>}`.  Before interpreting the config, `floki` will substitute the user's environmental variables for those values.
+
+```yaml
+docker_switches:
+  - -v ${user_env:HOME}/.vim:/home/build/.vim
+```
+
+Only alphanumeric and underscores (`[a-zA-Z0-9_]`) are supported in environmental variable names.  Inclusion of other characters afer `user_env` will prevent the substitution from taking place.
+
+Warning:
+- Use of host environmental variables may reduce the reproducibility and shareability of your `floki.yaml`.
+- If an environmental variable is not found, it is interpreted as a blank string.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,9 @@ pub enum FlokiError {
     #[error("There was a problem opening the configuration file '{name}': {error:?}")]
     ProblemOpeningConfigYaml { name: String, error: io::Error },
 
+    #[error("There was a problem reading the configuration file '{name}': {error:?}")]
+    ProblemReadingConfigYaml { name: String, error: io::Error },
+
     #[error("There was a problem parsing the configuration file '{name}': {error:?}")]
     ProblemParsingConfigYaml {
         name: String,


### PR DESCRIPTION
Alternative to [PR for Tera-based implementation](https://github.com/Metaswitch/floki/pull/296)

## Why this change?

This allows users to reference environmental variables in floki.yaml, for example to mount a $HOME subdirectory in a container as
```yaml
docker-switches:
  - -v ${user_env:HOME}/.vim:/home/build/.vim
 ```

Any string matching `\$\{user_env:([a-zA-Z0-9_]*)\}` is captured by floki before deserialization, and the user's environmental variable name following `user_env:` is substituted in.

## Relevant testing

- New UT added,
- Tested manually against a local floki.yaml file which successfully mounted a directory declared as `${user_env:HOME}`, and printed a host environmental variable in the container in an init command.

## Contributor notes

See Teams chat for idea discussion.

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

