### PR TITLE
Add basic one-shot tera support, to enable use of environmental varia…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Status: Available for use
 ## [Unreleased]
 
 ### Breaking Changes
+- Interpret floki.yaml as a template using tera.  Among other function, this allows use of environmental variables in floki config.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ shlex = "1.1"
 sha2 = "0.10.7"
 anyhow = "1.0.71"
 thiserror = "1.0.40"
+tera = "1"
 
 [dev-dependencies]
 tempfile = "3.6.0"

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -222,3 +222,12 @@ Note that use of `docker_switches` may reduce the reproducibility and shareabili
 
 Nonetheless, it is useful to be able to add arbitrary switches in a pinch, just to be able to get something working.
 If there are things you can add with `docker_switches` which are reproducible and shareable, please raise a feature request, or go ahead and implement it yourself!
+
+# Templating
+
+`floki` supports templating using the [Tera engine](https://tera.netlify.app/).  Currently this is executed as a one-shot rendering of your `floki.yaml`.  Example uses include referencing environmental variables in the `floki` config, e.g. to mount a subdirectory of the user's home directory:
+```yaml
+docker_switches:
+  - -v {{ get_env(name='HOME') }}/.vim:/home/build/.vim
+```
+Note that extensive use may reduce the reproducibility and shareability of your `floki.yaml`

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,7 +107,7 @@ impl FlokiConfig {
                 error: e,
             })?;
 
-        let contents = Tera::one_off(&contents, &Context::new(), true).map_err(|e| {
+        let contents = Tera::one_off(&contents, &Context::new(), false).map_err(|e| {
             errors::FlokiError::ProblemRenderingConfig {
                 name: file.display().to_string(),
                 error: e,
@@ -193,7 +193,7 @@ mod test {
         let content = Tera::one_off(
             "image: \"prefix_{{ get_env(name='image') }}:1.1\"",
             &Context::new(),
-            true,
+            false,
         )
         .unwrap();
         let actual: TestImageConfig = serde_yaml::from_str(&content).unwrap();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,8 +19,13 @@ pub enum FlokiError {
     #[error("Could not normalize the file path '{name}': {error:?}")]
     ProblemNormalizingFilePath { name: String, error: io::Error },
 
-    #[error("There was a problem opening the configuration file '{name}': {error:?}")]
-    ProblemOpeningConfigYaml { name: String, error: io::Error },
+    #[error("There was a problem reading the configuration file '{name}': {error:?}")]
+    ProblemReadingConfigFile { name: String, error: io::Error },
+
+    #[error(
+        "There was a problem rendering configuration from the template file '{name}': {error:?}"
+    )]
+    ProblemRenderingConfig { name: String, error: tera::Error },
 
     #[error("There was a problem parsing the configuration file '{name}': {error:?}")]
     ProblemParsingConfigYaml {


### PR DESCRIPTION
Alternative to [PR for regex-based implementation](https://github.com/Metaswitch/floki/pull/294)

## Why this change?

This allows users to use Tera templating for additional flexibility with their `floki.yaml`.  The target use case is to reference environmental variables in floki.yaml, for example to mount a $HOME subdirectory in a container as
```yaml
docker-switches:
  - -v {{ get_env(name='HOME' }}/.vim:/home/build/.vim
 ```

## Relevant testing

- New UT added,
- Tested manually against a local floki.yaml file which successfully mounted a directory declared as `{{ get_env('HOME`) }}, and similarly printed a host environmental variable in the container in an init command.

## Contributor notes

See Teams chat for idea discussion.
Subsequently discussed using Tera with Max

## Checks

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
  - Documentation, not readme, as this is more advanced use.
- [x] `CHANGELOG.md` updated for this change

