### PR TITLE
Combine errors into a single FlokiError enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Status: Available for use
   can use `toml(file="<filepath>")` in order to load values.
 - Add `floki render` to print out the rendered configuration template.
 - Switch rust image to `rust:1-alpine3.18` as it's better maintained.
+- Combine errors into a single FlokiError enum.
 
 ### Fixed
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,6 +65,14 @@ pub enum FlokiError {
 
     #[error("Malformed item in docker_switches: {item}")]
     MalformedDockerSwitch { item: String },
+
+    /// Internal error for floki - these represent failed assumptions of
+    /// the developers, and shouldn't actually manifest.
+    #[error("An internal assertion failed '{description}'.  This is probably a bug!")]
+    InternalAssertionFailed { description: String },
+
+    #[error("Invalid verbosity setting of {setting:?}. Use a setting between 0 and 3 (-vvv)")]
+    InvalidVerbositySetting { setting: u8 },
 }
 
 /// Generate a summary string for a process exiting
@@ -97,19 +105,4 @@ impl fmt::Display for FlokiSubprocessExitStatus {
             exit_code_diagnosis(&self.exit_status)
         )
     }
-}
-
-/// Internal error types for floki - these represent failed assumptions of
-/// the developers, and shouldn't actually manifest.
-#[derive(Debug, thiserror::Error)]
-pub enum FlokiInternalError {
-    #[error("An internal assertion failed '{description}'.  This is probably a bug!")]
-    InternalAssertionFailed { description: String },
-}
-
-/// Errors made by floki users.
-#[derive(Debug, thiserror::Error)]
-pub enum FlokiUserError {
-    #[error("Invalid verbosity setting of {setting:?}. Use a setting between 0 and 3 (-vvv)")]
-    InvalidVerbositySetting { setting: u8 },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use anyhow::Error;
 use cli::{Cli, Subcommand};
 use config::FlokiConfig;
 use environment::Environment;
+use errors::FlokiError;
 use structopt::StructOpt;
 
 fn main() -> Result<(), Error> {
@@ -87,11 +88,7 @@ fn configure_logging(verbosity: u8) -> Result<(), Error> {
         1 => log::LevelFilter::Info,
         2 => log::LevelFilter::Debug,
         3 => log::LevelFilter::Trace,
-        _ => {
-            return Err(
-                errors::FlokiUserError::InvalidVerbositySetting { setting: verbosity }.into(),
-            )
-        }
+        _ => return Err(FlokiError::InvalidVerbositySetting { setting: verbosity }.into()),
     };
     simplelog::TermLogger::init(
         level,


### PR DESCRIPTION
## Why this change?

Having three sets of errors seemed a bit much.

## Relevant testing

Unit testing

## Contributor notes

Anything you think will be useful for reviewers.

## Checks

These aren't hard requirements, just guidelines

- [ ] New/modified Rust code formatted with `cargo fmt`
- [ ] Documentation and `README.md` updated for this change, if necessary
- [ ] `CHANGELOG.md` updated for this change

