### PR TITLE
Use shell_words to split the outer shell so that more complex outer shells can be used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Status: Available for use
 ### Added
 
 ### Fixed
+- #62: Use shell_words to split the outer shell so that more complex outer shells can be used.
 
 ## [1.2.0] - 2023-07-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "shell-words",
  "shlex",
  "simplelog",
  "structopt",
@@ -818,6 +819,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0.40"
 tera = "1"
 serde_json = "1.0.100"
 toml = "0.7.6"
+shell-words = "1.1.0"
 
 [dev-dependencies]
 tempfile = "3.6.0"

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,11 +40,13 @@ impl Drop for DaemonHandle {
 }
 
 impl DockerCommandBuilder {
-    pub fn run(&self, command: &[&str]) -> Result<(), Error> {
-        debug!(
-            "Spawning docker command with configuration: {:?} args: {:?}",
-            self, command
-        );
+    pub fn run<I, S>(&self, command: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = S> + std::fmt::Debug,
+        S: AsRef<OsStr>,
+    {
+        debug!("Spawning docker command with configuration: {self:?}");
+        debug!("- and args: {command:?}");
 
         let mut command = Command::new("docker")
             .args(self.base_args())

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -53,8 +53,13 @@ pub(crate) fn run_floki_container(
         None
     };
 
+    // Calculate the outer shell command.
     let subshell_command = subshell_command(&spec.init, inner_command);
-    cmd.run(&[spec.shell.outer_shell(), "-c", &subshell_command])
+    let mut outer_shell_cmd = shell_words::split(spec.shell.outer_shell())?;
+    outer_shell_cmd.push("-c".to_string());
+    outer_shell_cmd.push(subshell_command);
+
+    cmd.run(outer_shell_cmd)
 }
 
 pub(crate) fn command_in_shell(shell: &str, command: &[String]) -> String {


### PR DESCRIPTION
## Why this change?

Fixes #62

## Relevant testing

Local testing:
```
shell:
  inner: bash
  outer: su - root
```
becomes
```
08:55:42 [DEBUG] (1) floki::command: - and args: ["su", "-", "root", "-c", "bash"]
```

## Contributor notes

Anything you think will be useful for reviewers.

## Checks

These aren't hard requirements, just guidelines

- [ ] New/modified Rust code formatted with `cargo fmt`
- [ ] Documentation and `README.md` updated for this change, if necessary
- [ ] `CHANGELOG.md` updated for this change

