### PR TITLE
Load values from files relative to the floki config file, not from the current working directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Status: Available for use
 
 ### Fixed
 - #62: Use shell_words to split the outer shell so that more complex outer shells can be used.
+- Load values from files relative to the floki config file, not from the
+  current working directory.
 
 ## [1.2.0] - 2023-07-07
 


### PR DESCRIPTION
## Why this change?

Not everyone has floki.yaml in the root directory, nor runs floki.yaml from the root directory. This ensures that file resolution for the new `yaml`, `toml` and `json` function are deterministic - the path that is being loaded can always be determined.

## Relevant testing

Local testing.

## Checks

These aren't hard requirements, just guidelines

- [ ] New/modified Rust code formatted with `cargo fmt`
- [ ] Documentation and `README.md` updated for this change, if necessary
- [ ] `CHANGELOG.md` updated for this change

