### PR TITLE
Allow entrypoints by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,22 @@ on:
     types: [ opened, synchronize ]
 
 jobs:
+  lint:
+    name: Linting and Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Run cargo clippy to pick up any errors
+        run: cargo clippy --all-targets -- -Dwarnings
+      - name: Check code is formatted
+        run: cargo fmt -- --check
+
   build:
+    name: Build static binary for publishing
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -36,9 +51,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.rust }}
-      - name: Run cargo clippy to pick up any errors
-        if: ${{ matrix.rust == 'stable' }}
-        run: cargo clippy -- -Dwarnings
+      - name: Run tests
+        run: cargo test --all-features
       - run: pip3 install -U tomlq
       - run: "./build.sh"
         env:
@@ -53,22 +67,19 @@ jobs:
             floki*.tar.gz
 
   publish:
-    runs-on: ubuntu-20.04
+    name: Publish release artifact
+    runs-on: ubuntu-latest
+    if: github.ref_type == "tag"
     needs:
       - build
     steps:
       - uses: actions/checkout@v4
-      - run: pip3 install -U tomlq
       - name: Install rust
-        uses: dtolnay/rust-toolchain@stable
-      - name: Publish to crates.io on tags
-        if: startsWith(github.ref, 'refs/tags/')
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: stable
+      - name: Publish to crates.io
         run: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.PUBLISH_SECRET }}
-      - name: Dry-run publish on non-tags
-        if: startsWith(github.ref, 'refs/tags/') != true
-        run: cargo publish --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.PUBLISH_SECRET }}
       # After publishing, create a release
@@ -76,11 +87,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: stableartifacts
+      - run: pip3 install -U tomlq
       - name: Generate release.txt
         run: "./changelog.sh"
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: release.txt
           token: ${{ secrets.PAT_GITHUB }}
@@ -89,6 +100,20 @@ jobs:
             floki*.tar.gz
       # Announce the release
       - run: "./announce.sh"
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           ANNOUNCE_HOOK: ${{ secrets.ANNOUNCE_HOOK }}
+
+  publish-dry-run:
+    name: Dry-run publish for non-release artifact
+    runs-on: ubuntu-latest
+    if: github.ref_type != "tag"
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Dry-run publish on non-tags
+        run: cargo publish --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   publish:
     name: Publish release artifact
     runs-on: ubuntu-latest
-    if: github.ref_type == "tag"
+    if: github.ref_type == 'tag'
     needs:
       - build
     steps:
@@ -106,7 +106,7 @@ jobs:
   publish-dry-run:
     name: Dry-run publish for non-release artifact
     runs-on: ubuntu-latest
-    if: github.ref_type != "tag"
+    if: github.ref_type != 'tag'
     needs:
       - build
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Status: Available for use
 ## [Unreleased]
 
 ### Breaking Changes
+- Change entrypoint suppression to allow entrypoints by default
 
 ### Added
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,6 @@ TAG=$(tomlq -r '.package.version' Cargo.toml)
 
 LABEL=${TAG}-${OS_ID}
 
-rm -rf target
 echo "Starting release build for ${LABEL}"
 
 if [ ${OS_ID} = "linux" ]
@@ -30,7 +29,6 @@ then
   ldd floki
 
   tar -cvzf floki-${LABEL}.tar.gz floki
-
 else
   echo "Building release binary"
   cargo build --release

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -116,11 +116,11 @@ The commands to make the above work depend on the container you are running. `fl
 
 # Entrypoints
 
-By default `floki` will suppress the container entrypoint. This can be overridden in the configuration file with:
+Some images define entrypoints to start services or to configure run-time settings that might not be what's wanted when using the image as a development environment.  To suppress any defined entrypoint in the image use:
 
 ```yaml
 entrypoint:
-  suppress: false
+  suppress: true
 ```
 
 # Docker-in-docker

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ impl Shell {
 
 impl Default for Shell {
     fn default() -> Self {
-        Self::Shell("sh".into())
+        Self::Shell("/bin/sh".into())
     }
 }
 


### PR DESCRIPTION
## Why this change?

Following the principle of least surprise, don't suppress image entrypoints unless asked to.

## Relevant testing

Tested with an image that runs an entrypoint before starting the image.

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

