### PR TITLE
Switch out actions-rs toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,14 @@ jobs:
             rust: nightly
             experimental: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.rust }}
       - name: Run cargo clippy to pick up any errors
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'stable' }}
-        with:
-          toolchain: ${{ matrix.rust }}
-          command: clippy
-          args: -- -Dwarnings
+        run: cargo clippy -- -Dwarnings
       - run: pip3 install -U tomlq
       - run: "./build.sh"
         env:
@@ -61,27 +57,18 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pip3 install -U tomlq
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Publish to crates.io on tags
-        uses: actions-rs/cargo@v1
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          toolchain: stable
-          command: publish
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.PUBLISH_SECRET }}
       - name: Dry-run publish on non-tags
-        uses: actions-rs/cargo@v1
         if: startsWith(github.ref, 'refs/tags/') != true
-        with:
-          toolchain: stable
-          command: publish
-          args: --dry-run
+        run: cargo publish --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.PUBLISH_SECRET }}
       # After publishing, create a release


### PR DESCRIPTION
As per https://github.com/actions-rs/toolchain/issues/216, actions-rs is not being actively maintained. Switch to a maintained version.