### PR TITLE
Add `FLOKI_WORKING_DIR` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Status: Available for use
 ### Breaking Changes
 
 ### Added
+- Add `FLOKI_WORKING_DIR` environment variable that is accessible inside the
+  container. Can be used when `mount:` has been specified in `floki.yaml`.
 
 ### Fixed
 

--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -181,7 +181,7 @@ These can be used to configure users in the container dynamically. This can be a
 
 The host path to the mounted directory is forwarded into the `floki` container as an environment variable, `FLOKI_HOST_MOUNTDIR`.
 
-You can set where this directory is mounted in the container using the `mount` key in `floki.yaml`.
+You can set where this directory is mounted in the container using the `mount` key in `floki.yaml`. The mount location is exposed in the `floki` container as an environment variable, `FLOKI_WORKING_DIR`.
 
 ## SSH agent
 

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -23,6 +23,7 @@ pub(crate) fn run_floki_container(
     cmd = cmd.add_environment("FLOKI_HOST_MOUNTDIR", &spec.paths.root);
     cmd = cmd.add_environment("FLOKI_HOST_UID", spec.user.uid.to_string());
     cmd = cmd.add_environment("FLOKI_HOST_GID", spec.user.gid.to_string());
+    cmd = cmd.add_environment("FLOKI_WORKING_DIR", &spec.paths.internal_working_directory);
     cmd = cmd.set_working_directory(&spec.paths.internal_working_directory);
 
     if spec.user.forward {


### PR DESCRIPTION
- Add `FLOKI_WORKING_DIR` environment variable that is accessible inside the container. Can be used when `mount:` has been specified in `floki.yaml`.

## Why this change?

If someone specifies `mount:` then the assumption that code is mounted at /src is wrong.

## Relevant testing

Local testing

## Contributor notes

N/A

## Checks

These aren't hard requirements, just guidelines

- [x] New/modified Rust code formatted with `cargo fmt`
- [x] Documentation and `README.md` updated for this change, if necessary
- [x] `CHANGELOG.md` updated for this change

