### PR TITLE
fix: restore get_env() template function

### DIFF
--- a/docs/content/intro/feature-overview.md
+++ b/docs/content/intro/feature-overview.md
@@ -232,4 +232,6 @@ Example uses include referencing environmental variables in the `floki` config, 
 docker_switches:
   - -v {{ env.HOME }}/.vim:/home/build/.vim
 ```
+`get_env(name="HOME")` is also available, and takes an optional `default` for when the variable isn't set.
+
 Note that extensive use may reduce the reproducibility and shareability of your `floki.yaml`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,6 +195,20 @@ fn makeloader(
     }
 }
 
+// Reimplementation of tera 1's `get_env`, which was dropped in tera 2.
+fn get_env(kwargs: tera::Kwargs, _: &tera::State) -> tera::TeraResult<tera::Value> {
+    let name: String = kwargs.must_get("name")?;
+    match std::env::var(&name) {
+        Ok(value) => Ok(value.into()),
+        Err(_) => match kwargs.get::<tera::Value>("default")? {
+            Some(default) => Ok(default),
+            None => Err(tera::Error::message(format!(
+                "Environment variable `{name}` not found"
+            ))),
+        },
+    }
+}
+
 // Renders a template from a given string.
 pub fn render_template(template: &str, source_filename: &Path) -> Result<String, FlokiError> {
     let template_path = source_filename.display().to_string();
@@ -216,6 +230,7 @@ pub fn render_template(template: &str, source_filename: &Path) -> Result<String,
     tera.register_function("yaml", makeloader(&canonical_path, LoaderType::Yaml));
     tera.register_function("json", makeloader(&canonical_path, LoaderType::Json));
     tera.register_function("toml", makeloader(&canonical_path, LoaderType::Toml));
+    tera.register_function("get_env", get_env);
 
     tera.add_raw_template(&template_path, template)
         .map_err(|e| FlokiError::ProblemRenderingTemplate {
@@ -411,6 +426,34 @@ mod test {
         let config = render_template(template, Path::new("floki.yaml"))?;
         assert_eq!(config, "floki: floki");
         Ok(())
+    }
+
+    #[test]
+    fn test_tera_get_env() -> Result<(), Box<dyn std::error::Error>> {
+        // Uses PATH rather than setting a var, as set_var is unsound in a threaded
+        // test binary.
+        let template = r#"shell: {{ get_env(name="PATH") }}"#;
+        assert_eq!(
+            render_template(template, Path::new("floki.yaml"))?,
+            format!("shell: {}", std::env::var("PATH")?)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_tera_get_env_default() -> Result<(), Box<dyn std::error::Error>> {
+        let template = r#"shell: {{ get_env(name="FLOKI_TEST_UNSET", default="bar") }}"#;
+        assert_eq!(
+            render_template(template, Path::new("floki.yaml"))?,
+            "shell: bar"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_tera_get_env_missing_errors() {
+        let template = r#"shell: {{ get_env(name="FLOKI_TEST_UNSET") }}"#;
+        assert!(render_template(template, Path::new("floki.yaml")).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #576.

tera 2 dropped the built-in `get_env()`, so `floki.yaml` files using it stopped rendering as of floki 2.4.4:

```
[ERROR] A problem occurred: There was a problem rendering the template 'floki.yaml': Unknown function `get_env`
```

## The fix

Reimplement `get_env` as a custom tera function and register it alongside the existing `yaml`/`json`/`toml` loaders. Same signature as tera 1: `get_env(name="HOME")`, with an optional `default` used when the variable is unset, and an error otherwise.

## CI coverage

Three unit tests in `src/config.rs` cover the set, defaulted, and missing-and-no-default cases. `cargo test` already runs on every PR, so a future tera bump that drops `get_env` again fails the build rather than shipping.

Docs updated to mention `get_env` alongside the existing `env.*` example.